### PR TITLE
Fix for #60 and #61

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/twitch_exporter   /bin/twitch_exporter
+RUN chmod +x /bin/twitch_exporter
 
 EXPOSE     9184
 ENTRYPOINT [ "/bin/twitch_exporter" ]

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ DOCKER_REPO  ?= damoun
 include Makefile.common
 
 DOCKER_IMAGE_NAME ?= twitch-exporter
+
+promu-build:
+	@echo ">> running promu crossbuild -v"
+	promu crossbuild -v


### PR DESCRIPTION
Adding `chmod +x` to Dockerfile, to make sure the exporter binary is always executable regardless of which permissions it may have on the host system. 

Not really important but added a `make promu-build` command to alias the promu build command just to try to keep everything inside the makefile and not have to remember the promu build exact command

Fixed missing log messages when requests are successful but return a non 200 status code and adjusted the wording around each log message to be more unique and easy to relate where the errors are actually coming from. 

Later I may look at the other issues you have here and may refactor a bit around the error messages. 