### PR TITLE
#86 - Disable collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ make
 * __`version`:__ Show application version.
 * __`web.listen-address`:__ Address to listen on for web interface and telemetry.
 * __`web.telemetry-path`:__ Path under which to expose metrics.
+* __`--[no-]collector.channel_followers_total`:__ Enable the channel_followers_total collector (default: enabled).
+* __`--[no-]collector.channel_subscribers_total`:__ Enable the channel_subscribers_total collector (default: disabled)..
+* __`--[no-]collector.channel_up`:__ Enable the channel_up collector (default: enabled).
+* __`--[no-]collector.channel_viewers_total`:__ Enable the channel_viewers_total collector (default: enabled).
 
 ## Useful Queries
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make
 * __`web.listen-address`:__ Address to listen on for web interface and telemetry.
 * __`web.telemetry-path`:__ Path under which to expose metrics.
 * __`--[no-]collector.channel_followers_total`:__ Enable the channel_followers_total collector (default: enabled).
-* __`--[no-]collector.channel_subscribers_total`:__ Enable the channel_subscribers_total collector (default: disabled)..
+* __`--[no-]collector.channel_subscribers_total`:__ Enable the channel_subscribers_total collector (default: disabled).
 * __`--[no-]collector.channel_up`:__ Enable the channel_up collector (default: enabled).
 * __`--[no-]collector.channel_viewers_total`:__ Enable the channel_viewers_total collector (default: enabled).
 

--- a/collector/channel_followers_total.go
+++ b/collector/channel_followers_total.go
@@ -1,0 +1,79 @@
+package collector
+
+import (
+	"errors"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelFollowersTotalCollector struct {
+	logger       log.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelFollowers typedDesc
+}
+
+func init() {
+	registerCollector("channel_followers_total", defaultEnabled, NewChannelFollowersTotalCollector)
+}
+
+func NewChannelFollowersTotalCollector(logger log.Logger, client *helix.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelFollowersTotalCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelFollowers: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_followers_total"),
+			"The number of followers of a channel.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c channelFollowersTotalCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		level.Error(c.logger).Log("msg", "Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		level.Error(c.logger).Log("msg", "Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	// todo: we can avoid this with a shared cache of username to userID that has a short TTL
+	for _, user := range usersResp.Data.Users {
+		usersFollowsResp, err := c.client.GetChannelFollows(&helix.GetChannelFollowsParams{
+			BroadcasterID: user.ID,
+		})
+
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Failed to collect follower stats from Twitch helix API", "err", err)
+			return err
+		}
+
+		if usersFollowsResp.StatusCode != 200 {
+			level.Error(c.logger).Log("msg", "Failed to collect follower stats from Twitch helix API", "err", usersFollowsResp.ErrorMessage)
+			return errors.New(usersFollowsResp.ErrorMessage)
+		}
+
+		ch <- c.channelFollowers.mustNewConstMetric(float64(usersFollowsResp.Data.Total), user.DisplayName)
+	}
+
+	return nil
+}

--- a/collector/channel_names.go
+++ b/collector/channel_names.go
@@ -1,0 +1,22 @@
+package collector
+
+import "fmt"
+
+// ChannelNames represents a list of twitch channels.
+type ChannelNames []string
+
+// IsCumulative is required for kingpin interfaces to allow multiple values
+func (c ChannelNames) IsCumulative() bool {
+	return true
+}
+
+// Set sets the value of a ChannelNames
+func (c *ChannelNames) Set(v string) error {
+	*c = append(*c, v)
+	return nil
+}
+
+// String returns a string representation of the Channels type.
+func (c ChannelNames) String() string {
+	return fmt.Sprintf("%v", []string(c))
+}

--- a/collector/channel_subscribers_total.go
+++ b/collector/channel_subscribers_total.go
@@ -1,0 +1,107 @@
+package collector
+
+import (
+	"errors"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	giftedSub    = "true"
+	notGiftedSub = "false"
+)
+
+type ChannelSubscriberTotalCollector struct {
+	logger       log.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelSubscribersTotal typedDesc
+}
+
+func init() {
+	registerCollector("channel_subscribers_total", defaultDisabled, NewChannelSubscriberTotalCollector)
+}
+
+func NewChannelSubscriberTotalCollector(logger log.Logger, client *helix.Client, channelNames ChannelNames) (Collector, error) {
+	c := ChannelSubscriberTotalCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelSubscribersTotal: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_subscribers_total"),
+			"The number of subscriber of a channel.",
+			[]string{"username", "tier", "gifted"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c ChannelSubscriberTotalCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		level.Error(c.logger).Log("msg", "Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		level.Error(c.logger).Log("msg", "Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	// todo: we can avoid this with a shared cache of username to userID that has a short TTL
+	for _, user := range usersResp.Data.Users {
+		subscribtionsResp, err := c.client.GetSubscriptions(&helix.SubscriptionsParams{
+			BroadcasterID: user.ID,
+		})
+
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Failed to collect subscribers stats from Twitch helix API", "err", err)
+			return err
+		}
+
+		if subscribtionsResp.StatusCode != 200 {
+			level.Error(c.logger).Log("msg", "Failed to collect subscirbers stats from Twitch helix API", "err", subscribtionsResp.ErrorMessage)
+			return errors.New(subscribtionsResp.ErrorMessage)
+		}
+
+		subCounter := make(map[string]int)
+		giftedSubCounter := make(map[string]int)
+
+		for _, subscription := range subscribtionsResp.Data.Subscriptions {
+			if subscription.IsGift {
+				if _, ok := giftedSubCounter[subscription.Tier]; !ok {
+					giftedSubCounter[subscription.Tier] = 0
+				}
+				giftedSubCounter[subscription.Tier] = giftedSubCounter[subscription.Tier] + 1
+			} else {
+				if _, ok := subCounter[subscription.Tier]; !ok {
+					subCounter[subscription.Tier] = 0
+				}
+				subCounter[subscription.Tier] = subCounter[subscription.Tier] + 1
+			}
+		}
+
+		for tier, counter := range giftedSubCounter {
+			ch <- c.channelSubscribersTotal.mustNewConstMetric(float64(counter), user.DisplayName, tier, giftedSub)
+		}
+
+		for tier, counter := range subCounter {
+			ch <- c.channelSubscribersTotal.mustNewConstMetric(float64(counter), user.DisplayName, tier, notGiftedSub)
+		}
+	}
+
+	return nil
+}

--- a/collector/channel_up.go
+++ b/collector/channel_up.go
@@ -1,0 +1,69 @@
+package collector
+
+import (
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelUpCollector struct {
+	logger       log.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelUp typedDesc
+}
+
+func init() {
+	registerCollector("channel_up", defaultEnabled, NewChannelUpCollector)
+}
+
+func NewChannelUpCollector(logger log.Logger, client *helix.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelUpCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelUp: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_up"),
+			"Is the channel live.",
+			[]string{"username", "game"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c channelUpCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	streamsResp, err := c.client.GetStreams(&helix.StreamsParams{
+		UserLogins: c.channelNames,
+		First:      len(c.channelNames),
+	})
+
+	if err != nil {
+		level.Error(c.logger).Log("msg", "could not get streams", "err", err)
+		return err
+	}
+
+	for _, n := range c.channelNames {
+		state := 0
+		game := ""
+
+		for _, s := range streamsResp.Data.Streams {
+			if s.UserName == n {
+				state = 1
+				game = s.GameName
+				break
+			}
+		}
+
+		ch <- c.channelUp.mustNewConstMetric(float64(state), n, game)
+	}
+
+	return nil
+}

--- a/collector/channel_viewers_total.go
+++ b/collector/channel_viewers_total.go
@@ -1,0 +1,58 @@
+package collector
+
+import (
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ChannelViewersTotalCollector struct {
+	logger       log.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelViewersTotal typedDesc
+}
+
+func init() {
+	registerCollector("channel_viewers_total", defaultEnabled, NewChannelViewersTotalCollector)
+}
+
+func NewChannelViewersTotalCollector(logger log.Logger, client *helix.Client, channelNames ChannelNames) (Collector, error) {
+	c := ChannelViewersTotalCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelViewersTotal: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_viewers_total"),
+			"How many viewers on this live channel. If stream is offline then this is absent.",
+			[]string{"username", "game"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c ChannelViewersTotalCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	streamsResp, err := c.client.GetStreams(&helix.StreamsParams{
+		UserLogins: c.channelNames,
+		First:      len(c.channelNames),
+	})
+
+	if err != nil {
+		level.Error(c.logger).Log("msg", "could not get streams", "err", err)
+		return err
+	}
+
+	for _, s := range streamsResp.Data.Streams {
+		ch <- c.channelViewersTotal.mustNewConstMetric(float64(s.ViewerCount), s.UserName, s.GameName)
+	}
+
+	return nil
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,0 +1,198 @@
+// Much of this file has been referenced from:
+// https://github.com/prometheus/node_exporter/blob/master/collector/collector.go
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const namespace = "twitch"
+
+var (
+	scrapeDurationDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "scrape", "collector_duration_seconds"),
+		"node_exporter: Duration of a collector scrape.",
+		[]string{"collector"},
+		nil,
+	)
+	scrapeSuccessDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "scrape", "collector_success"),
+		"node_exporter: Whether a collector succeeded.",
+		[]string{"collector"},
+		nil,
+	)
+)
+
+const (
+	defaultEnabled  = true
+	defaultDisabled = false
+)
+
+var (
+	factories              = make(map[string]func(logger log.Logger, client *helix.Client, channelNames ChannelNames) (Collector, error))
+	initiatedCollectorsMtx = sync.Mutex{}
+	initiatedCollectors    = make(map[string]Collector)
+	collectorState         = make(map[string]*bool)
+	forcedCollectors       = map[string]bool{} // collectors which have been explicitly enabled or disabled
+)
+
+func registerCollector(collector string, isDefaultEnabled bool, factory func(logger log.Logger, client *helix.Client, channelNames ChannelNames) (Collector, error)) {
+	var helpDefaultState string
+	if isDefaultEnabled {
+		helpDefaultState = "enabled"
+	} else {
+		helpDefaultState = "disabled"
+	}
+
+	flagName := "collector." + collector
+	flagHelp := fmt.Sprintf("Enable the %s collector (default: %s).", collector, helpDefaultState)
+	defaultValue := fmt.Sprintf("%v", isDefaultEnabled)
+
+	flag := kingpin.Flag(flagName, flagHelp).Default(defaultValue).Action(collectorFlagAction(collector)).Bool()
+	collectorState[collector] = flag
+
+	factories[collector] = factory
+}
+
+type Exporter struct {
+	Collectors map[string]Collector
+	client     *helix.Client
+	logger     log.Logger
+}
+
+// Describe describes all the metrics ever exported by the Twitch exporter. It
+// implements prometheus.Collector.
+func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- scrapeDurationDesc
+	ch <- scrapeSuccessDesc
+}
+
+func DisableDefaultCollectors() {
+	for c := range collectorState {
+		if _, ok := forcedCollectors[c]; !ok {
+			*collectorState[c] = false
+		}
+	}
+}
+
+// collectorFlagAction generates a new action function for the given collector
+// to track whether it has been explicitly enabled or disabled from the command line.
+// A new action function is needed for each collector flag because the ParseContext
+// does not contain information about which flag called the action.
+// See: https://github.com/alecthomas/kingpin/issues/294
+func collectorFlagAction(collector string) func(ctx *kingpin.ParseContext) error {
+	return func(ctx *kingpin.ParseContext) error {
+		forcedCollectors[collector] = true
+		return nil
+	}
+}
+
+func NewExporter(logger log.Logger, client *helix.Client, channelNames ChannelNames, filters ...string) (*Exporter, error) {
+	f := make(map[string]bool)
+	for _, filter := range filters {
+		enabled, exist := collectorState[filter]
+		if !exist {
+			return nil, fmt.Errorf("missing collector: %s", filter)
+		}
+
+		if !*enabled {
+			return nil, fmt.Errorf("disabled collector: %s", filter)
+		}
+		f[filter] = true
+	}
+
+	collectors := make(map[string]Collector)
+	initiatedCollectorsMtx.Lock()
+	defer initiatedCollectorsMtx.Unlock()
+	for key, enabled := range collectorState {
+		if !*enabled || (len(f) > 0 && !f[key]) {
+			continue
+		}
+		if collector, ok := initiatedCollectors[key]; ok {
+			collectors[key] = collector
+		} else {
+			collector, err := factories[key](logger, client, channelNames)
+			if err != nil {
+				return nil, err
+			}
+			collectors[key] = collector
+			initiatedCollectors[key] = collector
+		}
+	}
+
+	for k, _ := range collectors {
+		level.Info(logger).Log("msg", "enabled collector", "collector", k)
+	}
+
+	return &Exporter{
+		Collectors: collectors,
+
+		client: client,
+		logger: logger,
+	}, nil
+}
+
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(e.Collectors))
+	for name, c := range e.Collectors {
+		go func(name string, c Collector) {
+			execute(name, c, ch, e.logger)
+			wg.Done()
+		}(name, c)
+	}
+	wg.Wait()
+}
+
+func execute(name string, c Collector, ch chan<- prometheus.Metric, logger log.Logger) {
+	begin := time.Now()
+	err := c.Update(ch)
+	duration := time.Since(begin)
+	var success float64
+
+	if err != nil {
+		if IsNoDataError(err) {
+			level.Error(logger).Log("collector returned no data", "name", name, "duration_seconds", duration.Seconds(), "err", err)
+		} else {
+			level.Error(logger).Log("collector failed", "name", name, "duration_seconds", duration.Seconds(), "err", err)
+		}
+		success = 0
+	} else {
+		level.Info(logger).Log("collector succeeded", "name", name, "duration_seconds", duration.Seconds())
+		success = 1
+	}
+
+	ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, duration.Seconds(), name)
+	ch <- prometheus.MustNewConstMetric(scrapeSuccessDesc, prometheus.GaugeValue, success, name)
+}
+
+// Collector is the interface a collector has to implement.
+type Collector interface {
+	// Get new metrics and expose them via prometheus registry.
+	Update(ch chan<- prometheus.Metric) error
+}
+
+type typedDesc struct {
+	desc      *prometheus.Desc
+	valueType prometheus.ValueType
+}
+
+func (d *typedDesc) mustNewConstMetric(value float64, labels ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(d.desc, d.valueType, value, labels...)
+}
+
+var ErrNoData = errors.New("collector returned no data")
+
+func IsNoDataError(err error) bool {
+	return err == ErrNoData
+}


### PR DESCRIPTION
- Add functionality to disable collectors based on a flag.
- Split collectors into files, allowing for creating new metric collectors much easier
---

This does not combine well with a `prober` type collectors, which is why that was disabled. New issue incoming.

resolves #86 