### PR TITLE
Refresh tokens

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 jobs:
   build:
@@ -46,12 +47,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: make docker DOCKER_IMAGE_TAG="${{ github.ref_name }}"
-      - run: make docker-publish DOCKER_IMAGE_TAG="${{ github.ref_name }}"
-      - run: make docker-manifest DOCKER_IMAGE_TAG="${{ github.ref_name }}"
+      - run: make docker DOCKER_REPO="${{ secrets.DOCKER_REPO }}" DOCKER_IMAGE_NAME="${{ secrets.DOCKER_IMAGE_NAME }}" DOCKER_IMAGE_TAG="${{ github.ref_name }}"
+      - run: make docker-publish DOCKER_REPO="${{ secrets.DOCKER_REPO }}" DOCKER_IMAGE_NAME="${{ secrets.DOCKER_IMAGE_NAME }}" DOCKER_IMAGE_TAG="${{ github.ref_name }}"
+      - run: make docker-manifest DOCKER_REPO="${{ secrets.DOCKER_REPO }}" DOCKER_IMAGE_NAME="${{ secrets.DOCKER_IMAGE_NAME }}" DOCKER_IMAGE_TAG="${{ github.ref_name }}"
       - if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          make docker-tag-latest DOCKER_IMAGE_TAG="${{ github.ref_name }}"
-          make docker-publish DOCKER_IMAGE_TAG="latest"
-          make docker-manifest DOCKER_IMAGE_TAG="latest"
-      - run: docker run docker.io/damoun/twitch-exporter-linux-amd64:main --help
+          make docker-tag-latest DOCKER_REPO="${{ secrets.DOCKER_REPO }}" DOCKER_IMAGE_NAME="${{ secrets.DOCKER_IMAGE_NAME }}" DOCKER_IMAGE_TAG="${{ github.ref_name }}"
+          make docker-publish DOCKER_REPO="${{ secrets.DOCKER_REPO }}" DOCKER_IMAGE_NAME="${{ secrets.DOCKER_IMAGE_NAME }}" DOCKER_IMAGE_TAG="latest"
+          make docker-manifest DOCKER_REPO="${{ secrets.DOCKER_REPO }}" DOCKER_IMAGE_NAME="${{ secrets.DOCKER_IMAGE_NAME }}" DOCKER_IMAGE_TAG="latest"
+      - run: docker run docker.io/${{ secrets.DOCKER_REPO }}/${{ secrets.DOCKER_IMAGE_NAME }}:${{ github.ref_name }} --help

--- a/charts/twitch-exporter/templates/deployment.yaml
+++ b/charts/twitch-exporter/templates/deployment.yaml
@@ -21,6 +21,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -30,27 +35,34 @@ spec:
             {{- if .Values.twitch.accessToken }}
             # access token is provided as a secret
             "--twitch.access-token=$(TWITCH_ACCESS_TOKEN)",
-            {{ end -}}
+            {{- end -}}
 
             {{- if .Values.twitch.refreshToken }}
             # refresh token is provided as a secret
             "--twitch.refresh-token=$(TWITCH_REFRESH_TOKEN)",
-            {{ end -}}
+            {{- end -}}
+
+            {{- if .Values.twitch.clientId }}
+            # client id is provided as a secret
+            "--twitch.client-id=$(TWITCH_CLIENT_ID)",
+            {{- end -}}
 
             {{- if .Values.twitch.clientSecret }}
             # client secret is provided as a secret
             "--twitch.client-secret=$(TWITCH_CLIENT_SECRET)",
-            {{ end -}}
+            {{- end -}}
 
-            # config is provided as a config map
-            "--config=/var/secrets/config.yml"
+            {{- range .Values.twitch.channels }}
+            "--twitch.channel={{ . }}",
+            {{- end }}
           ]
           envFrom:
             - secretRef:
                 name: twitch-exporter-env
+          {{- if .Values.volumeMounts }}
           volumeMounts:
-            - name: twitch-exporter-config
-              mountPath: /var/secrets
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -63,7 +75,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      volumes:
-        - name: twitch-exporter-config
-          configMap:
-            name: twitch-exporter-config
+        {{- if .Values.volumes }}
+        volumes:
+          {{- toYaml .Values.volumes | nindent 12 }}
+        {{- end }}

--- a/charts/twitch-exporter/templates/deployment.yaml
+++ b/charts/twitch-exporter/templates/deployment.yaml
@@ -25,16 +25,32 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+
           args: [
-            "--twitch.client-id=$(TWITCH_CLIENT_ID)",
+            {{- if .Values.twitch.accessToken }}
+            # access token is provided as a secret
             "--twitch.access-token=$(TWITCH_ACCESS_TOKEN)",
-            {{- with $.Values.twitch.channels }}{{ range $.Values.twitch.channels }}
-            "--twitch.channel={{ . }}",
-            {{- end }}{{- end }}
+            {{ end -}}
+
+            {{- if .Values.twitch.refreshToken }}
+            # refresh token is provided as a secret
+            "--twitch.refresh-token=$(TWITCH_REFRESH_TOKEN)",
+            {{ end -}}
+
+            {{- if .Values.twitch.clientSecret }}
+            # client secret is provided as a secret
+            "--twitch.client-secret=$(TWITCH_CLIENT_SECRET)",
+            {{ end -}}
+
+            # config is provided as a config map
+            "--config=/var/secrets/config.yml"
           ]
           envFrom:
             - secretRef:
                 name: twitch-exporter-env
+          volumeMounts:
+            - name: twitch-exporter-config
+              mountPath: /var/secrets
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -47,3 +63,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      volumes:
+        - name: twitch-exporter-config
+          configMap:
+            name: twitch-exporter-config

--- a/charts/twitch-exporter/templates/secrets.yaml
+++ b/charts/twitch-exporter/templates/secrets.yaml
@@ -4,5 +4,18 @@ metadata:
   name: twitch-exporter-env
 type: Opaque
 stringData:
-  TWITCH_CLIENT_ID: "{{ .Values.twitch.clientId }}"
   TWITCH_ACCESS_TOKEN: "{{ .Values.twitch.accessToken }}"
+  TWITCH_REFRESH_TOKEN: "{{ .Values.twitch.refreshToken }}"
+
+  TWITCH_CLIENT_SECRET: "{{ .Values.twitch.clientSecret }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: twitch-exporter-config
+data:
+  config.yml: |
+    twitch:
+      clientId: "{{ .Values.twitch.clientId }}"
+      channels:
+        {{- toYaml .Values.twitch.channels | nindent 8 }}

--- a/charts/twitch-exporter/templates/secrets.yaml
+++ b/charts/twitch-exporter/templates/secrets.yaml
@@ -8,14 +8,3 @@ stringData:
   TWITCH_REFRESH_TOKEN: "{{ .Values.twitch.refreshToken }}"
 
   TWITCH_CLIENT_SECRET: "{{ .Values.twitch.clientSecret }}"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: twitch-exporter-config
-data:
-  config.yml: |
-    twitch:
-      clientId: "{{ .Values.twitch.clientId }}"
-      channels:
-        {{- toYaml .Values.twitch.channels | nindent 8 }}

--- a/charts/twitch-exporter/values.yaml
+++ b/charts/twitch-exporter/values.yaml
@@ -28,10 +28,10 @@ image:
   tag: "latest"
 
   # pullSecrets is a list of secrets to use for pulling the image.
+  # this secret must exist within the namespace of the chart.
   pullSecrets: []
   # pullSecrets:
   #   - name: dockerhub
-  #     namespace: default
 
 serviceAccount:
   create: true

--- a/charts/twitch-exporter/values.yaml
+++ b/charts/twitch-exporter/values.yaml
@@ -27,6 +27,12 @@ image:
   pullPolicy: Always
   tag: "latest"
 
+  # pullSecrets is a list of secrets to use for pulling the image.
+  pullSecrets: []
+  # pullSecrets:
+  #   - name: dockerhub
+  #     namespace: default
+
 serviceAccount:
   create: true
   automount: true
@@ -43,3 +49,6 @@ resources: {}
 podLabels: {}
 
 podAnnotations: {}
+
+volumes: []
+volumeMounts: []

--- a/charts/twitch-exporter/values.yaml
+++ b/charts/twitch-exporter/values.yaml
@@ -1,6 +1,21 @@
 twitch:
+  # client-id is required at all times
   clientId: ""
+
+  # client secret is preferred for use without private data, as it uses no oauth
+  # flow to grant access to the API. Endpoints such as sub counts are not with
+  # this method.
+  #
+  # if both client-secret and access-token are provided, client-secret will be
+  # used.
+  clientSecret: ""
+
+  # access-token & refresh-token are required for use with private data, such
+  # as sub counts.
   accessToken: ""
+  refreshToken: ""
+
+  # channels is a list of channels to export metrics for.
   channels:
     - jordofthenorth
     - timthetatman
@@ -24,3 +39,7 @@ ingress:
   enabled: false
 
 resources: {}
+
+podLabels: {}
+
+podAnnotations: {}

--- a/collector/channel_followers_total.go
+++ b/collector/channel_followers_total.go
@@ -46,12 +46,12 @@ func (c channelFollowersTotalCollector) Update(ch chan<- prometheus.Metric) erro
 	})
 
 	if err != nil {
-		c.logger.Error("msg", "Failed to collect users stats from Twitch helix API", "err", err)
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
 		return err
 	}
 
 	if usersResp.StatusCode != 200 {
-		c.logger.Error("msg", "Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
 		return errors.New(usersResp.ErrorMessage)
 	}
 
@@ -62,12 +62,12 @@ func (c channelFollowersTotalCollector) Update(ch chan<- prometheus.Metric) erro
 		})
 
 		if err != nil {
-			c.logger.Error("msg", "Failed to collect follower stats from Twitch helix API", "err", err)
+			c.logger.Error("Failed to collect follower stats from Twitch helix API", "err", err)
 			return err
 		}
 
 		if usersFollowsResp.StatusCode != 200 {
-			c.logger.Error("msg", "Failed to collect follower stats from Twitch helix API", "err", usersFollowsResp.ErrorMessage)
+			c.logger.Error("Failed to collect follower stats from Twitch helix API", "err", usersFollowsResp.ErrorMessage)
 			return errors.New(usersFollowsResp.ErrorMessage)
 		}
 

--- a/collector/channel_subscribers_total.go
+++ b/collector/channel_subscribers_total.go
@@ -51,12 +51,12 @@ func (c ChannelSubscriberTotalCollector) Update(ch chan<- prometheus.Metric) err
 	})
 
 	if err != nil {
-		c.logger.Error("msg", "Failed to collect users stats from Twitch helix API", "err", err)
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
 		return err
 	}
 
 	if usersResp.StatusCode != 200 {
-		c.logger.Error("msg", "Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
 		return errors.New(usersResp.ErrorMessage)
 	}
 
@@ -67,12 +67,12 @@ func (c ChannelSubscriberTotalCollector) Update(ch chan<- prometheus.Metric) err
 		})
 
 		if err != nil {
-			c.logger.Error("msg", "Failed to collect subscribers stats from Twitch helix API", "err", err)
+			c.logger.Error("Failed to collect subscribers stats from Twitch helix API", "err", err)
 			return err
 		}
 
 		if subscribtionsResp.StatusCode != 200 {
-			c.logger.Error("msg", "Failed to collect subscirbers stats from Twitch helix API", "err", subscribtionsResp.ErrorMessage)
+			c.logger.Error("Failed to collect subscirbers stats from Twitch helix API", "err", subscribtionsResp.ErrorMessage)
 			return errors.New(subscribtionsResp.ErrorMessage)
 		}
 

--- a/collector/channel_up.go
+++ b/collector/channel_up.go
@@ -46,7 +46,7 @@ func (c channelUpCollector) Update(ch chan<- prometheus.Metric) error {
 	})
 
 	if err != nil {
-		c.logger.Error("msg", "could not get streams", "err", err)
+		c.logger.Error("could not get streams", "err", err)
 		return err
 	}
 

--- a/collector/channel_viewers_total.go
+++ b/collector/channel_viewers_total.go
@@ -46,7 +46,7 @@ func (c ChannelViewersTotalCollector) Update(ch chan<- prometheus.Metric) error 
 	})
 
 	if err != nil {
-		c.logger.Error("msg", "could not get streams", "err", err)
+		c.logger.Error("could not get streams", "err", err)
 		return err
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -130,7 +130,7 @@ func NewExporter(logger *slog.Logger, client *helix.Client, channelNames Channel
 	}
 
 	for k, _ := range collectors {
-		logger.Info("msg", "enabled collector", "collector", k)
+		logger.Info("enabled collector", "collector", k)
 	}
 
 	return &Exporter{

--- a/twitch_exporter.go
+++ b/twitch_exporter.go
@@ -151,7 +151,7 @@ func newClientWithSecret(logger *slog.Logger) (*helix.Client, error) {
 	})
 
 	if err != nil {
-		logger.Error("msg", "could not initialise twitch client", "err", err)
+		logger.Error("could not initialise twitch client", "err", err)
 		return nil, err
 	}
 

--- a/twitch_exporter.go
+++ b/twitch_exporter.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/damoun/twitch_exporter/collector"
@@ -28,10 +29,14 @@ var (
 		Default("/metrics").String()
 	twitchClientID = kingpin.Flag("twitch.client-id",
 		"Client ID for the Twitch Helix API.").Required().String()
+	twitchClientSecret = kingpin.Flag("twitch.client-secret",
+		"Client Secret for the Twitch Helix API.").String()
 	twitchChannel = Channels(kingpin.Flag("twitch.channel",
 		"Name of a Twitch Channel to request metrics."))
 	twitchAccessToken = kingpin.Flag("twitch.access-token",
-		"Access Token for the Twitch Helix API.").Required().String()
+		"Access Token for the Twitch Helix API.").String()
+	twitchRefreshToken = kingpin.Flag("twitch.refresh-token",
+		"Refresh Token for the Twitch Helix API.").String()
 )
 
 type promHTTPLogger struct {
@@ -39,7 +44,7 @@ type promHTTPLogger struct {
 }
 
 func (l promHTTPLogger) Println(v ...interface{}) {
-	l.logger.Error("msg", fmt.Sprint(v...))
+	l.logger.Error(fmt.Sprint(v...))
 }
 
 // Channels creates a collection of Channels from a kingpin command line argument.
@@ -56,28 +61,39 @@ func init() {
 func main() {
 	promslogConfig := &promslog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promslogConfig)
+
 	var webConfig = webflag.AddFlags(kingpin.CommandLine, ":9184")
 	kingpin.Version(version.Print("twitch_exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
 	logger := promslog.New(promslogConfig)
-	logger.Info("msg", "Starting twitch_exporter", "version", version.Info())
-	logger.Info("build_context", version.BuildContext())
+	logger.Info("Starting twitch_exporter", "version", version.Info())
+	logger.Info("", "build_context", version.BuildContext())
 
-	client, err := helix.NewClient(&helix.Options{
-		ClientID:        *twitchClientID,
-		UserAccessToken: *twitchAccessToken,
-	})
+	var client *helix.Client
+	var err error
 
-	if err != nil {
-		logger.Error("msg", "could not initialise twitch client", "err", err)
-		return
+	if *twitchClientSecret != "" {
+		client, err = newClientWithSecret(logger)
+		if err != nil {
+			logger.Error("Error creating the client", "err", err)
+			os.Exit(1)
+		}
+	} else if *twitchAccessToken != "" && *twitchRefreshToken != "" {
+		client, err = newClientWithUserAccessToken(logger)
+		if err != nil {
+			logger.Error("Error creating the client", "err", err)
+			os.Exit(1)
+		}
+	} else {
+		logger.Error("Error creating the client", "err", "no client secret or access token provided")
+		os.Exit(1)
 	}
 
 	exporter, err := collector.NewExporter(logger, client, *twitchChannel)
 	if err != nil {
-		logger.Error("msg", "Error creating the exporter", "err", err)
+		logger.Error("Error creating the exporter", "err", err)
 		os.Exit(1)
 	}
 
@@ -106,7 +122,72 @@ func main() {
 
 	srv := &http.Server{}
 	if err := web.ListenAndServe(srv, webConfig, logger); err != nil {
-		logger.Error("msg", "Error starting HTTP server", "err", err)
+		logger.Error("Error starting HTTP server", "err", err)
 		os.Exit(1)
 	}
+}
+
+func refreshAppAccessToken(logger *slog.Logger, client *helix.Client) {
+	appAccessToken, err := client.RequestAppAccessToken([]string{})
+	if err != nil {
+		logger.Error("Error getting app access token", "err", err)
+		return
+	}
+
+	if appAccessToken.ErrorStatus != 0 {
+		logger.Error("Error getting app access token", "err", appAccessToken.Error)
+		return
+	}
+
+	client.SetAppAccessToken(appAccessToken.Data.AccessToken)
+}
+
+// newClientWithSecret creates a new Twitch client with the use of an app access
+// token.
+func newClientWithSecret(logger *slog.Logger) (*helix.Client, error) {
+	client, err := helix.NewClient(&helix.Options{
+		ClientID:     *twitchClientID,
+		ClientSecret: *twitchClientSecret,
+	})
+
+	if err != nil {
+		logger.Error("msg", "could not initialise twitch client", "err", err)
+		return nil, err
+	}
+
+	refreshAppAccessToken(logger, client)
+
+	// now set a ticker for ensuring the access token is refreshed, app access
+	// tokens do not return a refresh token, so we need to refresh them every
+	// 24 hours.
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	go func(logger *slog.Logger, client *helix.Client) {
+		for range ticker.C {
+			refreshAppAccessToken(logger, client)
+		}
+	}(logger, client)
+
+	return client, nil
+}
+
+// newClientWithUserAccessToken creates a new Twitch client with a user access token.
+// this is required for private data, such as subscriber counts.
+func newClientWithUserAccessToken(logger *slog.Logger) (*helix.Client, error) {
+	// providing a refresh token allows the helix client to refresh the access
+	// token when it expires. this is done automatically when using the helix
+	// client.
+	client, err := helix.NewClient(&helix.Options{
+		ClientID:        *twitchClientID,
+		UserAccessToken: *twitchAccessToken,
+		RefreshToken:    *twitchRefreshToken,
+	})
+
+	if err != nil {
+		logger.Error("Error creating the client", "err", err)
+		return nil, err
+	}
+
+	return client, nil
 }


### PR DESCRIPTION
- Implement the use of refreshing access tokens and application tokens, to allow for unmanaged ingest of metrics.
    - using access token and refresh token _should_ work, but untested
- 4 Secrets are used in the CI/CD pipeline to allow for me to build in my repo for testing;
    - DOCKERHUB_TOKEN (pre-existing)
    - DOCKERHUB_USERNAME (pre-existing)
    - DOCKER_IMAGE_NAME (if the dockerhub image name does not match the repo - eg testing instead of twitch_exporter)
    - DOCKER_REPO (if the dockerhub repo does not match the github repo - eg surdaft instead of damoun)
- provide chart configuration ability for image pull secrets, to allow for private registry pulls (used within testing)
- updated some log messages to follow the expected slog format, first param "msg" is unrequired and causes issues