### PR TITLE
fix: update refresh token after token refresh

### DIFF
--- a/twitch_exporter.go
+++ b/twitch_exporter.go
@@ -271,6 +271,7 @@ func refreshUserAccessToken(logger *slog.Logger, client *helix.Client) {
 	}
 
 	client.SetUserAccessToken(userAccessToken.Data.AccessToken)
+	client.SetRefreshToken(userAccessToken.Data.RefreshToken)
 }
 
 // newClientWithSecret creates a new Twitch client with the use of an app access


### PR DESCRIPTION
## Summary

- Fixes #63
- Updates the refresh token after each API-based token refresh

Twitch invalidates the old refresh token when issuing a new access token. The non-file-based refresh path was only updating the access token, causing subsequent refreshes to fail after 24 hours.

Note: The file-based refresh path (added in #117) already handles this correctly by re-reading both tokens from files.

## Test plan

- [ ] Deploy with user access token and refresh token (not using file-based tokens)
- [ ] Verify token refresh works after 24h cycle