### PR TITLE
feat: add channel_emotes_total metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ make
 | twitch_channel_viewers_total | Is the total number of viewers on an online twitch channel. | username, game |
 | twitch_channel_followers_total | Is the total number of follower on a twitch channel. | username |
 | twitch_channel_clips_total | Is the total number of clips on a twitch channel. | username |
+| twitch_channel_emotes_total | The number of custom emotes of a channel. | username |
 | twitch_channel_subscribers_total | Is the total number of subscriber on a twitch channel. | username, tier, gifted |
 | twitch_channel_subscription_points | The number of subscription points of a channel. | username |
 | twitch_channel_bits_leaderboard | The bits leaderboard score for users on a channel. | username, user_name, user_id, rank |

--- a/collector/channel_emotes_total.go
+++ b/collector/channel_emotes_total.go
@@ -1,0 +1,78 @@
+package collector
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/damoun/twitch_exporter/internal/eventsub"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelEmotesTotalCollector struct {
+	logger       *slog.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelEmotesTotal typedDesc
+}
+
+func init() {
+	registerCollector("channel_emotes_total", defaultEnabled, NewChannelEmotesTotalCollector)
+}
+
+func NewChannelEmotesTotalCollector(logger *slog.Logger, client *helix.Client, _ *eventsub.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelEmotesTotalCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelEmotesTotal: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_emotes_total"),
+			"The number of custom emotes of a channel.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c channelEmotesTotalCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	for _, user := range usersResp.Data.Users {
+		emotesResp, err := c.client.GetChannelEmotes(&helix.GetChannelEmotesParams{
+			BroadcasterID: user.ID,
+		})
+
+		if err != nil {
+			c.logger.Error("Failed to collect emotes from Twitch helix API", "err", err)
+			return err
+		}
+
+		if emotesResp.StatusCode != 200 {
+			c.logger.Error("Failed to collect emotes from Twitch helix API", "err", emotesResp.ErrorMessage)
+			return errors.New(emotesResp.ErrorMessage)
+		}
+
+		ch <- c.channelEmotesTotal.mustNewConstMetric(float64(len(emotesResp.Data.Emotes)), user.DisplayName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `twitch_channel_emotes_total` gauge metric reporting the number of custom emotes per channel
- Uses `GetChannelEmotes()` API — works with app token, default enabled
- Updates README metrics table

Closes #124