### PR TITLE
feat: add channel_moderators_total metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ make
 | twitch_channel_emotes_total | The number of custom emotes of a channel. | username |
 | twitch_channel_subscribers_total | Is the total number of subscriber on a twitch channel. | username, tier, gifted |
 | twitch_channel_subscription_points | The number of subscription points of a channel. | username |
+| twitch_channel_moderators_total | The number of moderators of a channel. | username |
 | twitch_channel_bits_leaderboard | The bits leaderboard score for users on a channel. | username, user_name, user_id, rank |
 | twitch_channel_chatters_total | The number of users in a channel's chat (only non-zero when channel is live). | username |
 | twitch_channel_chat_messages_total | Is the total number of chat messages from a user within a channel. | username, chatter_username |

--- a/collector/channel_moderators_total.go
+++ b/collector/channel_moderators_total.go
@@ -1,0 +1,92 @@
+package collector
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/damoun/twitch_exporter/internal/eventsub"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelModeratorsTotalCollector struct {
+	logger       *slog.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelModeratorsTotal typedDesc
+}
+
+func init() {
+	registerCollector("channel_moderators_total", defaultDisabled, NewChannelModeratorsTotalCollector)
+}
+
+func NewChannelModeratorsTotalCollector(logger *slog.Logger, client *helix.Client, _ *eventsub.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelModeratorsTotalCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelModeratorsTotal: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_moderators_total"),
+			"The number of moderators of a channel.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c channelModeratorsTotalCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	for _, user := range usersResp.Data.Users {
+		var total int
+		cursor := ""
+
+		for {
+			moderatorsResp, err := c.client.GetModerators(&helix.GetModeratorsParams{
+				BroadcasterID: user.ID,
+				First:         100,
+				After:         cursor,
+			})
+
+			if err != nil {
+				c.logger.Error("Failed to collect moderators from Twitch helix API", "err", err)
+				return err
+			}
+
+			if moderatorsResp.StatusCode != 200 {
+				c.logger.Error("Failed to collect moderators from Twitch helix API", "err", moderatorsResp.ErrorMessage)
+				return errors.New(moderatorsResp.ErrorMessage)
+			}
+
+			total += len(moderatorsResp.Data.Moderators)
+
+			if moderatorsResp.Data.Pagination.Cursor == "" {
+				break
+			}
+			cursor = moderatorsResp.Data.Pagination.Cursor
+		}
+
+		ch <- c.channelModeratorsTotal.mustNewConstMetric(float64(total), user.DisplayName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `twitch_channel_moderators_total` gauge metric reporting the number of moderators per channel
- Paginates through all moderators using the `After` cursor
- Requires user token with `moderation:read` scope — default disabled
- Updates README metrics table

Closes #125