### PR TITLE
feat: add channel_vips_total metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ make
 | twitch_channel_subscribers_total | Is the total number of subscriber on a twitch channel. | username, tier, gifted |
 | twitch_channel_subscription_points | The number of subscription points of a channel. | username |
 | twitch_channel_moderators_total | The number of moderators of a channel. | username |
+| twitch_channel_vips_total | The number of VIPs of a channel. | username |
 | twitch_channel_bits_leaderboard | The bits leaderboard score for users on a channel. | username, user_name, user_id, rank |
 | twitch_channel_chatters_total | The number of users in a channel's chat (only non-zero when channel is live). | username |
 | twitch_channel_chat_messages_total | Is the total number of chat messages from a user within a channel. | username, chatter_username |

--- a/collector/channel_vips_total.go
+++ b/collector/channel_vips_total.go
@@ -1,0 +1,92 @@
+package collector
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/damoun/twitch_exporter/internal/eventsub"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelVipsTotalCollector struct {
+	logger       *slog.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	channelVipsTotal typedDesc
+}
+
+func init() {
+	registerCollector("channel_vips_total", defaultDisabled, NewChannelVipsTotalCollector)
+}
+
+func NewChannelVipsTotalCollector(logger *slog.Logger, client *helix.Client, _ *eventsub.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelVipsTotalCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		channelVipsTotal: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_vips_total"),
+			"The number of VIPs of a channel.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c channelVipsTotalCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	for _, user := range usersResp.Data.Users {
+		var total int
+		cursor := ""
+
+		for {
+			vipsResp, err := c.client.GetChannelVips(&helix.GetChannelVipsParams{
+				BroadcasterID: user.ID,
+				First:         100,
+				After:         cursor,
+			})
+
+			if err != nil {
+				c.logger.Error("Failed to collect VIPs from Twitch helix API", "err", err)
+				return err
+			}
+
+			if vipsResp.StatusCode != 200 {
+				c.logger.Error("Failed to collect VIPs from Twitch helix API", "err", vipsResp.ErrorMessage)
+				return errors.New(vipsResp.ErrorMessage)
+			}
+
+			total += len(vipsResp.Data.ChannelsVips)
+
+			if vipsResp.Data.Pagination.Cursor == "" {
+				break
+			}
+			cursor = vipsResp.Data.Pagination.Cursor
+		}
+
+		ch <- c.channelVipsTotal.mustNewConstMetric(float64(total), user.DisplayName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `twitch_channel_vips_total` gauge metric reporting the number of VIPs per channel
- Paginates through all VIPs using the `After` cursor
- Requires user token with `channel:read:vips` scope — default disabled
- Updates README metrics table

Closes #126