### PR TITLE
feat: add channel_chat_settings metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ make
 | twitch_channel_banned_users_total | The number of banned users of a channel. | username |
 | twitch_channel_bits_leaderboard | The bits leaderboard score for users on a channel. | username, user_name, user_id, rank |
 | twitch_channel_chatters_total | The number of users in a channel's chat (only non-zero when channel is live). | username |
+| twitch_channel_chat_emote_only | Whether emote-only mode is enabled in a channel's chat. | username |
+| twitch_channel_chat_followers_only | Whether followers-only mode is enabled in a channel's chat. | username |
+| twitch_channel_chat_subscriber_only | Whether subscriber-only mode is enabled in a channel's chat. | username |
+| twitch_channel_chat_slow_mode | Whether slow mode is enabled in a channel's chat. | username |
+| twitch_channel_chat_slow_mode_wait_seconds | The slow mode wait time in seconds for a channel's chat. | username |
 | twitch_channel_chat_messages_total | Is the total number of chat messages from a user within a channel. | username, chatter_username |
 
 ### Flags

--- a/collector/channel_chat_settings.go
+++ b/collector/channel_chat_settings.go
@@ -1,0 +1,122 @@
+package collector
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/damoun/twitch_exporter/internal/eventsub"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelChatSettingsCollector struct {
+	logger       *slog.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	chatEmoteOnly           typedDesc
+	chatFollowersOnly       typedDesc
+	chatSubscriberOnly      typedDesc
+	chatSlowMode            typedDesc
+	chatSlowModeWaitSeconds typedDesc
+}
+
+func init() {
+	registerCollector("channel_chat_settings", defaultEnabled, NewChannelChatSettingsCollector)
+}
+
+func NewChannelChatSettingsCollector(logger *slog.Logger, client *helix.Client, _ *eventsub.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelChatSettingsCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		chatEmoteOnly: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_chat_emote_only"),
+			"Whether emote-only mode is enabled in a channel's chat.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+
+		chatFollowersOnly: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_chat_followers_only"),
+			"Whether followers-only mode is enabled in a channel's chat.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+
+		chatSubscriberOnly: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_chat_subscriber_only"),
+			"Whether subscriber-only mode is enabled in a channel's chat.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+
+		chatSlowMode: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_chat_slow_mode"),
+			"Whether slow mode is enabled in a channel's chat.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+
+		chatSlowModeWaitSeconds: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_chat_slow_mode_wait_seconds"),
+			"The slow mode wait time in seconds for a channel's chat.",
+			[]string{"username"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func boolToFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func (c channelChatSettingsCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	for _, user := range usersResp.Data.Users {
+		settingsResp, err := c.client.GetChatSettings(&helix.GetChatSettingsParams{
+			BroadcasterID: user.ID,
+		})
+
+		if err != nil {
+			c.logger.Error("Failed to collect chat settings from Twitch helix API", "err", err)
+			return err
+		}
+
+		if settingsResp.StatusCode != 200 {
+			c.logger.Error("Failed to collect chat settings from Twitch helix API", "err", settingsResp.ErrorMessage)
+			return errors.New(settingsResp.ErrorMessage)
+		}
+
+		if len(settingsResp.Data.Settings) == 0 {
+			continue
+		}
+
+		s := settingsResp.Data.Settings[0]
+		ch <- c.chatEmoteOnly.mustNewConstMetric(boolToFloat64(s.EmoteMode), user.DisplayName)
+		ch <- c.chatFollowersOnly.mustNewConstMetric(boolToFloat64(s.FollowerMode), user.DisplayName)
+		ch <- c.chatSubscriberOnly.mustNewConstMetric(boolToFloat64(s.SubscriberMode), user.DisplayName)
+		ch <- c.chatSlowMode.mustNewConstMetric(boolToFloat64(s.SlowMode), user.DisplayName)
+		ch <- c.chatSlowModeWaitSeconds.mustNewConstMetric(float64(s.SlowModeWaitTime), user.DisplayName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds 5 gauges from `GetChatSettings()` API — works with app token, default enabled:
  - `twitch_channel_chat_emote_only`
  - `twitch_channel_chat_followers_only`
  - `twitch_channel_chat_subscriber_only`
  - `twitch_channel_chat_slow_mode`
  - `twitch_channel_chat_slow_mode_wait_seconds`
- Updates README metrics table

Closes #129