### PR TITLE
feat: add channel_goals metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ make
 | twitch_channel_moderators_total | The number of moderators of a channel. | username |
 | twitch_channel_vips_total | The number of VIPs of a channel. | username |
 | twitch_channel_banned_users_total | The number of banned users of a channel. | username |
+| twitch_channel_goal_current | The current amount for a creator goal in a channel. | username, type |
+| twitch_channel_goal_target | The target amount for a creator goal in a channel. | username, type |
 | twitch_channel_bits_leaderboard | The bits leaderboard score for users on a channel. | username, user_name, user_id, rank |
 | twitch_channel_chatters_total | The number of users in a channel's chat (only non-zero when channel is live). | username |
 | twitch_channel_chat_messages_total | Is the total number of chat messages from a user within a channel. | username, chatter_username |

--- a/collector/channel_goals.go
+++ b/collector/channel_goals.go
@@ -1,0 +1,88 @@
+package collector
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/damoun/twitch_exporter/internal/eventsub"
+	"github.com/nicklaw5/helix/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type channelGoalsCollector struct {
+	logger       *slog.Logger
+	client       *helix.Client
+	channelNames ChannelNames
+
+	goalCurrent typedDesc
+	goalTarget  typedDesc
+}
+
+func init() {
+	registerCollector("channel_goals", defaultDisabled, NewChannelGoalsCollector)
+}
+
+func NewChannelGoalsCollector(logger *slog.Logger, client *helix.Client, _ *eventsub.Client, channelNames ChannelNames) (Collector, error) {
+	c := channelGoalsCollector{
+		logger:       logger,
+		client:       client,
+		channelNames: channelNames,
+
+		goalCurrent: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_goal_current"),
+			"The current amount for a creator goal in a channel.",
+			[]string{"username", "type"}, nil,
+		), prometheus.GaugeValue},
+
+		goalTarget: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "channel_goal_target"),
+			"The target amount for a creator goal in a channel.",
+			[]string{"username", "type"}, nil,
+		), prometheus.GaugeValue},
+	}
+
+	return c, nil
+}
+
+func (c channelGoalsCollector) Update(ch chan<- prometheus.Metric) error {
+	if len(c.channelNames) == 0 {
+		return ErrNoData
+	}
+
+	usersResp, err := c.client.GetUsers(&helix.UsersParams{
+		Logins: c.channelNames,
+	})
+
+	if err != nil {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", err)
+		return err
+	}
+
+	if usersResp.StatusCode != 200 {
+		c.logger.Error("Failed to collect users stats from Twitch helix API", "err", usersResp.ErrorMessage)
+		return errors.New(usersResp.ErrorMessage)
+	}
+
+	for _, user := range usersResp.Data.Users {
+		goalsResp, err := c.client.GetCreatorGoals(&helix.GetCreatorGoalsParams{
+			BroadcasterID: user.ID,
+		})
+
+		if err != nil {
+			c.logger.Error("Failed to collect creator goals from Twitch helix API", "err", err)
+			return err
+		}
+
+		if goalsResp.StatusCode != 200 {
+			c.logger.Error("Failed to collect creator goals from Twitch helix API", "err", goalsResp.ErrorMessage)
+			return errors.New(goalsResp.ErrorMessage)
+		}
+
+		for _, goal := range goalsResp.Data.Goals {
+			ch <- c.goalCurrent.mustNewConstMetric(float64(goal.CurrentAmount), user.DisplayName, goal.Type)
+			ch <- c.goalTarget.mustNewConstMetric(float64(goal.TargetAmount), user.DisplayName, goal.Type)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `twitch_channel_goal_current` and `twitch_channel_goal_target` gauges exposing creator goal progress
- Labels: `username`, `type` (e.g. "follower", "subscription")
- Requires user token with `channel:read:goals` scope — default disabled
- Updates README metrics table

Closes #132