### PR TITLE
fix: resolve all Trivy Helm chart security alerts

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# Namespace is determined at install time, not in the chart template
+KSV-0110
+
+# ghcr.io is a trusted registry (GitHub Container Registry)
+KSV-0125

--- a/charts/twitch-exporter/templates/deployment.yaml
+++ b/charts/twitch-exporter/templates/deployment.yaml
@@ -25,17 +25,27 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 12 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
           args: [
             {{- if .Values.twitch.accessToken }}
             # access token is provided as a secret

--- a/charts/twitch-exporter/values.yaml
+++ b/charts/twitch-exporter/values.yaml
@@ -35,7 +35,7 @@ twitch:
 image:
   repository: ghcr.io/damoun/twitch-exporter
   pullPolicy: Always
-  tag: "latest"
+  tag: ""
   pullSecrets: []
 
 serviceAccount:
@@ -51,7 +51,13 @@ ingress:
   enabled: false
   annotations: {}
 
-resources: {}
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
 
 podLabels: {}
 


### PR DESCRIPTION
## Summary
- Add pod-level and container-level `securityContext` with `runAsUser`/`runAsGroup` 65534, seccomp `RuntimeDefault` profile
- Set default resource requests/limits (cpu: 50m/200m, memory: 64Mi/128Mi)
- Change default image tag from `latest` to `""` (falls back to `Chart.AppVersion`)
- Add `.trivyignore` for KSV-0110 (default namespace, user's choice) and KSV-0125 (ghcr.io is trusted)

Resolves all 12 open Trivy code scanning alerts.

## Test plan
- [x] `trivy fs --scanners misconfig charts/` passes clean locally
- [ ] Verify code scanning alerts close after merge