### PR TITLE
fix: harden security context defaults and add Trivy ignores

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,6 @@
 # CPU limit not set — intentional, CPU limits cause throttling
 KSV011
+# Namespace is set at install time, not in the chart
+KSV110
+# Container image registry is user-configurable via image.repository
+KSV125

--- a/charts/twitch-exporter/values.yaml
+++ b/charts/twitch-exporter/values.yaml
@@ -51,11 +51,19 @@ serviceAccount:
 
 securityContext:
   runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
   fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
 
 containerSecurityContext:
+  runAsUser: 65534
+  runAsGroup: 65534
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
## Summary
- Add `runAsUser: 65534`, `runAsGroup: 65534`, and `seccompProfile.type: RuntimeDefault` to both `securityContext` and `containerSecurityContext` defaults in `values.yaml`
- Add `KSV110` (default namespace) and `KSV125` (trusted registries) to `.trivyignore` as they are user-configurable at install time

Fixes Trivy alerts #25, #26, #27, #28, #29, #31 from PR #150.

## Test plan
- [x] `helm lint` passes
- [x] `helm template` renders all new security context fields correctly