### PR TITLE
chore: bump chart version to 1.0.1

### DIFF
--- a/charts/twitch-exporter/Chart.yaml
+++ b/charts/twitch-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: twitch-exporter
 description: A Helm chart for twitch_exporter
 type: application
 
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.5"


### PR DESCRIPTION
## Summary
- Bump Helm chart version from 1.0.0 to 1.0.1 to reflect hardened security context defaults added in #154

## Test plan
- [x] `helm lint` passes