### PR TITLE
chore: bump versions for v1.1.0 release

### DIFF
--- a/charts/twitch-exporter/Chart.yaml
+++ b/charts/twitch-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: twitch-exporter
 description: A Helm chart for twitch_exporter
 type: application
 
-version: 1.0.1
-appVersion: "1.0.5"
+version: 1.0.2
+appVersion: "1.1.0"


### PR DESCRIPTION
## Summary

- Bump `appVersion` from `1.0.5` to `1.1.0` in `charts/twitch-exporter/Chart.yaml`
- Bump chart `version` from `1.0.1` to `1.0.2`

Since `v1.0.5`, many new collectors were added (emotes, moderators, vips, banned users, chat settings, goals, charity, info/delay, subscription points, chatters, clips, bits leaderboard), plus major refactors (slog migration, distroless Docker, GHCR migration, CI hardening).

## Test plan

- [x] `grep -E 'version|appVersion' charts/twitch-exporter/Chart.yaml` shows `version: 1.0.2` and `appVersion: "1.1.0"`