### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | yes       |
+| older   | no        |
+
+## Reporting a Vulnerability
+
+Use [GitHub private vulnerability reporting](https://github.com/damoun/twitch_exporter/security/advisories/new) as the primary channel.
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+**Response expectations:**
+- Acknowledgement within 7 days
+- No bug bounty program
+
+This project does not offer a bug bounty.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` at repo root
- Documents supported versions (latest minor only)
- Sets GitHub private vulnerability reporting as primary disclosure channel
- States 7-day acknowledgement SLA, no bug bounty

## Test plan

- [x] File exists at repo root
- [ ] GitHub Security tab shows the policy after merge