### PR TITLE
Pin GoReleaser to v2.14.3 and fix Docker attestation failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
-          version: latest
+          version: v2.14.3
           args: build --snapshot --clean
 
       - name: Verify version output

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
@@ -35,7 +37,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
-          version: latest
+          version: v2.14.3
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin GoReleaser CLI to v2.14.3 in both build and publish workflows (was `latest`)
- Add `docker/setup-buildx-action` to the publish workflow to fix the attestation error: `Attestation is not supported for the docker driver`

## Root cause
The `dockers_v2` goreleaser feature adds `--attest=type=sbom` by default, which requires the `docker-container` buildx driver. The publish workflow only had `setup-qemu-action` but was missing `setup-buildx-action`.

## Test plan
- [ ] Build workflow passes on this PR
- [ ] Re-release a tag to verify the publish workflow succeeds